### PR TITLE
Update tempo-core-i18n_de_DE.properties

### DIFF
--- a/system-plugins/tempo-core/de_DE/tempo-core-i18n_de_DE.properties
+++ b/system-plugins/tempo-core/de_DE/tempo-core-i18n_de_DE.properties
@@ -137,3 +137,11 @@ tempo-core.projects.recent=Zuletzt geöffnete Projekte
 tempo-core.restfultable.cancel=Abbrechen
 tempo-core.restfultable.delete=Löschen
 tempo-core.restfultable.save=Sichern
+
+tempo-core.admin.project.color.picker.label=Farbe wählen:
+tempo-core.admin.button.save=Speichern
+tempo-core.admin.project.color.description=Eine optionale benutzerdefinierte Farbe kann für ein JIRA Projekt gewählt werden, um Tempo Daten anzuzeigen und es von anderen JIRA Projekten zu unterscheiden. <br/> Wenn keine Farbe gewählt wird, wird das Tempo Standardfarbscheme benutzt.
+tempo-core.admin.project.color.picker.description=Die Farbe wird mit einem gültigen Farbcode gesetzt. Beispiel: #cccccc, #ec8e00, orange, blue
+tempo-core.admin.project.color.label=Farbe
+tempo-core.project.color.error=Bitte geben Sie eine gültige Farbe an
+tempo-core.error.not.found={0}: Nicht gefunden


### PR DESCRIPTION
Added missing translations in Core 2.0.6 for admin-tempo-core and admin-core
